### PR TITLE
README: Add execute permissions to ecs-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Install the ecs-cli by running the following (this assumes Linux - for other env
 
 ```bash
 sudo curl -Lo /usr/local/bin/ecs-cli https://amazon-ecs-cli.s3.amazonaws.com/ecs-cli-linux-amd64-latest
+sudo chmod +x /usr/local/bin/ecs-cli
 ```
 
 Using the Cluster Name outputted by successfully running the CDK template - run the following command:


### PR DESCRIPTION
Hi there, thanks for this awesome project. It got my server deploying in no time.

Minor documentation update: there is one step missing for linux after the download of `ecs-cli` executable.

As documented here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_CLI_installation.html#ECS_CLI_install_execute