### PR TITLE
Use named handler export rather than default export for lambdas

### DIFF
--- a/resources/serverstatus.ts
+++ b/resources/serverstatus.ts
@@ -35,7 +35,7 @@ const ec2Client = new EC2Client({ region: REGION });
 /**
  * Everything here has the assumption there is only one task.
  */
-const handler: APIGatewayProxyHandler = async (event: APIGatewayEvent, context: Context) => {
+export const handler: APIGatewayProxyHandler = async (event: APIGatewayEvent, context: Context) => {
   console.log(`New getServerStatus request: ${JSON.stringify(event)}`);
   console.log(`With context: ${JSON.stringify(context)}`);
 
@@ -50,8 +50,6 @@ const handler: APIGatewayProxyHandler = async (event: APIGatewayEvent, context: 
   };
 };
 
-export default handler;
-
 async function getIPFunction() {
 
   // Define the object that will hold the data values returned
@@ -62,7 +60,7 @@ async function getIPFunction() {
 
   try {
 
-    const listTasksCommandInput: ListTasksCommandInput = { 
+    const listTasksCommandInput: ListTasksCommandInput = {
       serviceName: SERVICE_ARN,
       cluster: CLUSTER_ARN,
       desiredStatus: "RUNNING"
@@ -70,7 +68,7 @@ async function getIPFunction() {
     const listTasksCommandResult = await ecsClient.send(new ListTasksCommand(listTasksCommandInput));
     console.log(listTasksCommandResult);
 
-    if (!listTasksCommandResult.taskArns || listTasksCommandResult.taskArns.length <= 0) return;
+    if (!listTasksCommandResult.taskArns || listTasksCommandResult.taskArns.length <= 0) return statusResults;
 
     const networkInterfaceId = await getNetworkInterfaceId(CLUSTER_ARN, listTasksCommandResult.taskArns);
 
@@ -79,7 +77,7 @@ async function getIPFunction() {
     }
     const describeNetworkInterfacesResult = await ec2Client.send(new DescribeNetworkInterfacesCommand(describeNetworkInterfacesInput));
 
-    if (!describeNetworkInterfacesResult.NetworkInterfaces || describeNetworkInterfacesResult.NetworkInterfaces.length <= 0) return;
+    if (!describeNetworkInterfacesResult.NetworkInterfaces || describeNetworkInterfacesResult.NetworkInterfaces.length <= 0) return statusResults;
     const publicIp = describeNetworkInterfacesResult.NetworkInterfaces.find(x => x.Association != undefined)?.Association?.PublicIp;
 
     console.log("found public IP " + publicIp);

--- a/resources/startstopserver.ts
+++ b/resources/startstopserver.ts
@@ -26,7 +26,7 @@ const SERVICE_NAME = process.env.SERVICE_NAME;
 const CLUSTER_ARN = process.env.CLUSTER_ARN; 
 const PASSWORD = process.env.PASSWORD;
 
-const handler: APIGatewayProxyHandler = async (event: APIGatewayEvent, context: Context) => {
+export const handler: APIGatewayProxyHandler = async (event: APIGatewayEvent, context: Context) => {
     console.log("request: " + JSON.stringify(event));
     let responseCode = 400;
     let message = "authentication failed";
@@ -54,10 +54,8 @@ const handler: APIGatewayProxyHandler = async (event: APIGatewayEvent, context: 
 
             const updateCommand = new UpdateServiceCommand(params);
 
-            client.send(updateCommand).then(
-                (data) => {console.log(data);},
-                (err) => {    console.log(err);}
-            );
+            const updateCommandResult = await client.send(updateCommand);
+            console.log(updateCommandResult);
         }
     }
 
@@ -78,5 +76,3 @@ const handler: APIGatewayProxyHandler = async (event: APIGatewayEvent, context: 
         body: JSON.stringify(responseBody)
     };
 };
-
-export default handler;


### PR DESCRIPTION
The lambdas were erroring with:
```
{
    "errorType": "Runtime.HandlerNotFound",
    "errorMessage": "index.handler is undefined or not exported"
}
```

AFAICT, the handler function needs to be a named, and not default, export.

Furthermore, it appeared that, in some cases at least, the startstop lambda could exit before the network request to the ECSClient completed. This also now awaits the response before exiting the lambda.

Finally, this causes the status lambda to always return some value.